### PR TITLE
Update version and addon ID

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 
     "name": "Princeton University News Study",
 
-    "version": "2.0.0",
+    "version": "2.0.1",
 
     "description": "A Rally study on how web users engage with news about politics and COVID-19.",
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 
     "name": "Princeton University News Study",
 
-    "version": "2.0",
+    "version": "2.0.0",
 
     "description": "A Rally study on how web users engage with news about politics and COVID-19.",
 
@@ -36,7 +36,7 @@
 
     "browser_specific_settings": {
         "gecko": {
-            "id": "rally.news.study@princeton.edu",
+            "id": "princeton-news-study@rally.mozilla.org",
             "strict_min_version": "87.0"
         }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "princeton-university-news-study",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "build": "rollup -c rollup.config.js",
     "dev": "rollup -w --config-enable-developer-mode -c rollup.config.js",


### PR DESCRIPTION
The AMO team requested we use an add-on ID ending in `@rally.mozilla.org`, also I've updated the version numbers in manifest and package json files to match.