### PR TITLE
correct path for output file, to prevent stripping characters from th…

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,7 +75,7 @@ export default (cliArgs) => {
     rollupConfig.push({
       input: scriptPath,
       output: {
-        file: `dist/${scriptPath.slice("study/".length)}`,
+        file: `dist/${scriptPath.slice("src/".length)}`,
         format: "iife",
         sourcemap: isDevMode(cliArgs) ? "inline" : false,
       },


### PR DESCRIPTION
…e beginning of scripts

We found during testing that worker scripts where getting characters removed from the beginning of the filename, for instance:
`src/aggregateStatistics.worker.js -> dist/gregateStatistics.worker.js`

I'm pretty sure this is because the roll-up config is expecting to strip "study" from the origin filename, and not "src".

This is working locally for me, and to unblock release activities I landed this on a `release` branch and tagged it for `2.0.1`, I'll make sure any changes on that branch are cherry-picked here as well.